### PR TITLE
Lambda exec role - define role and policy for lambda to assume into other accounts. 

### DIFF
--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement0",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::*:role/${prefix}_CstSecurityInspectorRole"
+        }
+    ]
+}

--- a/modules/agent_role/json/trust.json
+++ b/modules/agent_role/json/trust.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Statement0",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "lambda.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/modules/agent_role/output.tf
+++ b/modules/agent_role/output.tf
@@ -1,0 +1,7 @@
+output "role_id" {
+  value = "${aws_iam_role.cst_security_agent_role.id}"
+}
+
+output "policy_id" {
+  value = "${aws_iam_role_policy.cst_security_agent_role_policy.id}"
+}

--- a/modules/agent_role/policy.tf
+++ b/modules/agent_role/policy.tf
@@ -1,0 +1,15 @@
+data "template_file" "policy" {
+  template = "${file("${path.module}/json/policy.json")}"
+
+  vars {
+    prefix     = "${var.prefix}"
+    account_id = "${var.account_id}"
+  }
+}
+
+resource "aws_iam_role_policy" "cst_security_agent_role_policy" {
+  name = "${var.prefix}_CstSecurityAgentRolePolicy"
+  role = "${aws_iam_role.cst_security_agent_role.id}"
+
+  policy = "${data.template_file.policy.rendered}"
+}

--- a/modules/agent_role/security_agent_role.tf
+++ b/modules/agent_role/security_agent_role.tf
@@ -1,0 +1,14 @@
+data "template_file" "trust" {
+  template = "${file("${path.module}/json/trust.json")}"
+
+  vars {
+    prefix     = "${var.prefix}"
+    account_id = "${var.account_id}"
+  }
+}
+
+resource "aws_iam_role" "cst_security_agent_role" {
+  name = "${var.prefix}_CstSecurityAgentRole"
+
+  assume_role_policy = "${data.template_file.trust.rendered}"
+}

--- a/modules/agent_role/variables.tf
+++ b/modules/agent_role/variables.tf
@@ -1,0 +1,5 @@
+variable "prefix" {
+  default = "prod"
+}
+
+variable "account_id" {}

--- a/tools/csw/environments/example_environment/apply.tfvars
+++ b/tools/csw/environments/example_environment/apply.tfvars
@@ -2,8 +2,9 @@
 # set variables which may differ between environments and deployments
 
 tool = "csw"
-environment = "<insert env name>"
+environment = "<environment name>"
 prefix = "${var.tool}-${var.environment}"
+host_account_id = "<insert account_id the env runs in>"
 
 region = "eu-west-2"
 # these are not used at present but we could switch to define things using count across this array

--- a/tools/csw/main.tf
+++ b/tools/csw/main.tf
@@ -70,3 +70,9 @@ module "rds" {
 
   public_security_group_id = "${aws_security_group.public_security_group.id}"
 }
+
+module "lambda_exec_role" {
+  source     = "../../modules/agent_role"
+  prefix     = "${var.prefix}"
+  account_id = "${var.host_account_id}"
+}

--- a/tools/csw/output.tf
+++ b/tools/csw/output.tf
@@ -21,3 +21,11 @@ output "nat_1_public_ip" {
 output "nat_2_public_ip" {
   value = "${module.public_subnet_2.nat_public_ip_out}"
 }
+
+output "lambda_exec_role_id" {
+  value = "${module.lambda_exec_role.role_id}"
+}
+
+output "lambda_exec_policy_id" {
+  value = "${module.lambda_exec_role.policy_id}"
+}

--- a/tools/csw/variables.tf
+++ b/tools/csw/variables.tf
@@ -11,6 +11,7 @@ variable "tool" {
 }
 
 variable "environment" {}
+variable "host_account_id" {}
 
 variable "ip_16bit_prefix" {
   description = "Each VPC is created with a /16 bit mask meaning that if whilst they don't need to be addressable we should be able to keep all the internal IPs unique"


### PR DESCRIPTION
Creates a role and a policy using the users' prefix which can be assigned as the execution role of the chalice lambda functions which assume into other accounts. 