### PR TITLE
Enable dependency install via NPM, update terraform outputs to populate chalice config and add SSM ParameterStore permissions to exec roles

### DIFF
--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -64,8 +64,8 @@
             ],
             "Resource": [
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/api-credentials",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/auth/token-secret",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/rds/user"
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token-secret",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/user"
             ]
         },
         {

--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -59,12 +59,25 @@
             "Sid": "VisualEditor5",
             "Effect": "Allow",
             "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters"
+            ],
+            "Resource": [
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/*",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/terraform/*",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/{$prefix}/*"
+            ]
+        },
+        {
+            "Sid": "VisualEditor6",
+            "Effect": "Allow",
+            "Action": [
                 "support:DescribeTrustedAdvisorChecks"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "VisualEditor6",
+            "Sid": "VisualEditor7",
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeRegions"

--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -63,9 +63,9 @@
                 "ssm:GetParameters"
             ],
             "Resource": [
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/*",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/terraform/*",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/*"
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/api-credentials",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/auth/token-secret",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/rds/user"
             ]
         },
         {

--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -64,7 +64,7 @@
             ],
             "Resource": [
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/api-credentials",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token-secret",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token_secret",
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/user"
             ]
         },

--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -65,7 +65,7 @@
             "Resource": [
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/*",
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/terraform/*",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/{$prefix}/*"
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${prefix}/*"
             ]
         },
         {

--- a/modules/agent_role/policy.tf
+++ b/modules/agent_role/policy.tf
@@ -3,6 +3,7 @@ data "template_file" "policy" {
 
   vars {
     prefix      = "${var.prefix}"
+    environment = "${var.environment}"
     region      = "${var.region}"
     account_id  = "${var.account_id}"
   }

--- a/modules/agent_role/variables.tf
+++ b/modules/agent_role/variables.tf
@@ -1,4 +1,8 @@
 variable "prefix" {
+  default = "csw-prod"
+}
+
+variable "environment" {
   default = "prod"
 }
 

--- a/modules/developer_box_role/json/policy.json
+++ b/modules/developer_box_role/json/policy.json
@@ -68,7 +68,7 @@
             "Resource": [
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/api-credentials",
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/terraform/states-bucket",
-                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token-secret",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token_secret",
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/user",
                 "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/root"
 

--- a/modules/developer_box_role/json/policy.json
+++ b/modules/developer_box_role/json/policy.json
@@ -66,11 +66,11 @@
                 "ssm:PutParameter"
             ],
             "Resource": [
-                "arn:aws:ssm::${account_id}:parameter/csw/google/api-credentials",
-                "arn:aws:ssm::${account_id}:parameter/csw/terraform/states-bucket",
-                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/auth/token-secret",
-                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/rds/user",
-                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/rds/root"
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/google/api-credentials",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/terraform/states-bucket",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/auth/token-secret",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/user",
+                "arn:aws:ssm:${region}:${account_id}:parameter/csw/${environment}/rds/root"
 
             ]
         }

--- a/modules/developer_box_role/json/policy.json
+++ b/modules/developer_box_role/json/policy.json
@@ -56,6 +56,23 @@
             "Resource": [
                 "arn:aws:events:${region}:${account_id}:rule/*"
             ]
+        },
+        {
+            "Sid": "VisualEditor5",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:PutParameter"
+            ],
+            "Resource": [
+                "arn:aws:ssm::${account_id}:parameter/csw/google/api-credentials",
+                "arn:aws:ssm::${account_id}:parameter/csw/terraform/states-bucket",
+                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/auth/token-secret",
+                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/rds/user",
+                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/rds/root"
+
+            ]
         }
     ]
 }

--- a/modules/developer_box_role/json/policy.json
+++ b/modules/developer_box_role/json/policy.json
@@ -68,9 +68,9 @@
             "Resource": [
                 "arn:aws:ssm::${account_id}:parameter/csw/google/api-credentials",
                 "arn:aws:ssm::${account_id}:parameter/csw/terraform/states-bucket",
-                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/auth/token-secret",
-                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/rds/user",
-                "arn:aws:ssm::${account_id}:parameter/csw/${prefix}/rds/root"
+                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/auth/token-secret",
+                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/rds/user",
+                "arn:aws:ssm::${account_id}:parameter/csw/${environment}/rds/root"
 
             ]
         }

--- a/modules/developer_box_role/policy.tf
+++ b/modules/developer_box_role/policy.tf
@@ -3,6 +3,7 @@ data "template_file" "policy" {
 
   vars {
     prefix      = "${var.prefix}"
+    environment = "${var.environment}"
     region      = "${var.region}"
     account_id  = "${var.account_id}"
     bucket_name = "${var.bucket_name}"

--- a/modules/developer_box_role/variables.tf
+++ b/modules/developer_box_role/variables.tf
@@ -1,4 +1,8 @@
 variable "prefix" {
+  default = "csw-prod"
+}
+
+variable "environment" {
   default = "prod"
 }
 

--- a/modules/rds/output.tf
+++ b/modules/rds/output.tf
@@ -11,5 +11,5 @@ output "rds_security_group_id_out" {
 }
 
 output "rds_connection_string_out" {
-  value = "${aws_db_instance.address}"
+  value = "${aws_db_instance.rds.address}"
 }

--- a/modules/rds/output.tf
+++ b/modules/rds/output.tf
@@ -9,3 +9,7 @@ output "rds_subnet_group_id_out" {
 output "rds_security_group_id_out" {
   value = "${aws_security_group.rds_security_group.id}"
 }
+
+output "rds_connection_string_out" {
+  value = "${aws_db_instance.address}"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "csw-infra",
+  "description": "Terraform infrastructure for CST tools",
+  "version": "1.0.0",
+  "private": false,
+  "engines": {
+    "node": "^8.9.1"
+  }
+}

--- a/tools/csw/developer.tf
+++ b/tools/csw/developer.tf
@@ -63,6 +63,7 @@ resource "aws_security_group" "developer_security_group" {
 module "developer_box_role" {
   source            = "../../modules/developer_box_role"
   prefix            = "${var.prefix}"
+  environment       = "${var.environment}"
   region            = "${var.region}"
   bucket_name       = "${var.bucket_name}"
   account_id        = "${var.host_account_id}"

--- a/tools/csw/main.tf
+++ b/tools/csw/main.tf
@@ -76,8 +76,9 @@ module "rds" {
 }
 
 module "lambda_exec_role" {
-  source     = "../../modules/agent_role"
-  prefix     = "${var.prefix}"
-  region     = "${var.region}"
-  account_id = "${var.host_account_id}"
+  source        = "../../modules/agent_role"
+  prefix        = "${var.prefix}"
+  environment   = "${var.environment}"
+  region        = "${var.region}"
+  account_id    = "${var.host_account_id}"
 }

--- a/tools/csw/output.tf
+++ b/tools/csw/output.tf
@@ -14,7 +14,7 @@ output "rds_security_group_id" {
   value = "${module.rds.rds_security_group_id_out}"
 }
 
-output "rds_connection_string_out" {
+output "rds_connection_string" {
   value = "${module.rds.rds_connection_string_out}"
 }
 

--- a/tools/csw/output.tf
+++ b/tools/csw/output.tf
@@ -14,6 +14,10 @@ output "rds_security_group_id" {
   value = "${module.rds.rds_security_group_id_out}"
 }
 
+output "rds_connection_string_out" {
+  value = "${module.rds.rds_connection_string_out}"
+}
+
 output "bastion_public_ip" {
   value = "${module.jump_subnet.bastion_public_ip_out}"
 }


### PR DESCRIPTION
Added a package.json file to enable npm to install csw-infra as a dependency of the csw-backend code. 
Added the RDS connection string to the list of terraform outputs. 
Switched the policy to be consistent with naming of env and prefix input variables.
Since we have moved the credentials and secrets from SecretsManager to ParameterStore added the SSM permissions to both the execution role for the lambdas and the developer box policy