### PR TITLE
Correct assume role grant for inspector role ARN.

### DIFF
--- a/modules/agent_role/json/policy.json
+++ b/modules/agent_role/json/policy.json
@@ -8,7 +8,7 @@
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::*:role/csw-dan_CstSecurityInspectorRole"
+                "arn:aws:iam::*:role/csw-${environment}_CstSecurityInspectorRole"
             ]
         },
         {


### PR DESCRIPTION
The ARN still had my dev environment hard coded in the assume role policy statement. Corrected to pick up the variable environment name