### PR TITLE
CT-755 - Set rds instance type as a variable configurable by environment type

### DIFF
--- a/modules/rds/rds.tf
+++ b/modules/rds/rds.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "rds" {
   engine                    = "postgres"
   engine_version            = "9.5"
   identifier                = "${var.prefix}-postgres"
-  instance_class            = "db.t2.small"
+  instance_class            = "${var.rds_instance_type}"
   multi_az                  = false
   name                      = "${var.prefix}Postgres"
   final_snapshot_identifier = "${var.prefix}Postgres-${replace(timestamp(),var.regex,var.replace)}-final-snapshot"

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -11,3 +11,7 @@ variable "private_subnet_ids" {
 
 variable "public_security_group_id" {}
 variable "vpc_id" {}
+
+variable "rds_instance_type" {
+  default = "db.t2.small"
+}

--- a/tools/csw/main.tf
+++ b/tools/csw/main.tf
@@ -57,10 +57,11 @@ module "private_subnet_2" {
 }
 
 module "rds" {
-  source   = "../../modules/rds/"
-  vpc_id   = "${module.vpc.vpc_id_out}"
-  prefix   = "${var.tool}${var.environment}"
-  password = "${var.postgres_root_password}"
+  source            = "../../modules/rds/"
+  vpc_id            = "${module.vpc.vpc_id_out}"
+  prefix            = "${var.tool}${var.environment}"
+  password          = "${var.postgres_root_password}"
+  rds_instance_type = "${lookup(var.rds_instance_types, var.env_type)}"
 
   private_subnet_cidr_blocks = [
     "${module.private_subnet_1.private_subnet_cidr_block_out}",

--- a/tools/csw/variables.tf
+++ b/tools/csw/variables.tf
@@ -61,3 +61,14 @@ variable "gds_public_cidrs" {
 
 variable "chain_account_id" {}
 variable "chain_role_name" {}
+
+variable "rds_instance_types" {
+  default = {
+    production  = "db.t3.medium"
+    staging     = "db.t2.small"
+  }
+}
+
+variable "env_type" {
+  default = "staging"
+}

--- a/tools/csw/variables.tf
+++ b/tools/csw/variables.tf
@@ -64,7 +64,7 @@ variable "chain_role_name" {}
 
 variable "rds_instance_types" {
   default = {
-    production  = "db.t3.medium"
+    production  = "db.t2.medium"
     staging     = "db.t2.small"
   }
 }


### PR DESCRIPTION
apply.tfvars contains env_type (csw-backend branch ct-755) 
The env_type is then used to index the map rds_instance_types so we have a consistent instance type for all non-production envs and a different instance type for production.