### PR TITLE
CE-367 npm upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "private": false,
   "engines": {
-    "node": "^8.9.1"
+    "node": "^17.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "csw-infra",
   "description": "Terraform infrastructure for CST tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "engines": {
-    "node": "^17.0.0"
+    "node": "^16.9.1"
   }
 }


### PR DESCRIPTION
This just removes the node warning when the package.json installs csw-infra in order to wrapper up the terraform in the gulp workflow.